### PR TITLE
fix pattern .mat loading compatibility issue with Matlab 2020b on

### DIFF
--- a/MATLAB Code/IO_tools/make_flash_image.m
+++ b/MATLAB Code/IO_tools/make_flash_image.m
@@ -13,7 +13,7 @@ load('Pcontrol_paths.mat');
 dos(['del /Q "' temp_path '\*.pat"']); % SS
 
 for j = 1:num_patterns
-    load([file_list(j).PathName '\' file_list(j).FileName]);
+    load([file_list(j).PathName '\' file_list(j).FileName], 'pattern');
  
     % determine if row_compression is on
     row_compression(j) = 0;

--- a/MATLAB Code/controller/Pattern_Player.m
+++ b/MATLAB Code/controller/Pattern_Player.m
@@ -167,7 +167,7 @@ load('Pcontrol_paths.mat');
 cd(pattern_path)
 [FileName,PathName] = uigetfile('P*.mat','Select a Pattern File');
 if (all(FileName ~= 0))
-    load([PathName FileName]);
+    load([PathName FileName],'pattern');
     handles.pattern = pattern;
 
     handles.pattern_x_size = pattern.x_num;

--- a/MATLAB Code/controller/play_current_pattern.m
+++ b/MATLAB Code/controller/play_current_pattern.m
@@ -54,7 +54,7 @@ guidata(hObject, handles);
 global currentState;
 load('Pcontrol_paths.mat');
 pattFullName = fullfile(pattern_path, currentState.pattName);
-load(pattFullName);
+load(pattFullName,'pattern');
     
 if (all(pattFullName ~= 0))
     handles.pattern = pattern;

--- a/MATLAB Code/test_scripts/dump_check.m
+++ b/MATLAB Code/test_scripts/dump_check.m
@@ -2,7 +2,7 @@
 
 filename = fullfile(pathname, filename);
 
-load(filename);
+load(filename,'pattern');
 %load('D:\Michael_Reiser\XmegaController_Matlab\Patterns\Pattern_4x4_blocks_48.mat');
 pattern.row_compression = 0;
 


### PR DESCRIPTION
Matlab 2020b added the "pattern" class: https://www.mathworks.com/help/matlab/ref/pattern.html

This causes an issue when loading a pattern .mat file containing the variable "pattern", unless it is 
 i) explicitly assigned to a variable in the function workspace
 ii) initialized before loading
 iii) specified as a parameter in Matlab's "load" function
(more info here: https://www.mathworks.com/help/matlab/import_export/troubleshooting-loading-variables-within-a-function.html)

Used option iii) to specify the "pattern" variable as a parameter, in all functions I could find with the problematic loading.
As far as I can tell, "pattern" is the only variable used from the pattern .mat files in these functions. 

Cheers,
Ben